### PR TITLE
Display MAC for identified hosts

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -191,7 +191,10 @@ func getHostValue(host core.Host) string {
 		)
 	}
 	if host.IPv6 != "" {
-		value += fmt.Sprintf("%v<br>", host.IPv6)
+		value += fmt.Sprintf("IPv6: %v<br>", host.IPv6)
+	}
+	if host.MAC != "" {
+		value += fmt.Sprintf("MAC: %v<br>", host.MAC)
 	}
 
 	// Ports


### PR DESCRIPTION
closes #7 
I added displaying the MAC address for identified hosts. Are their circumstances where you do not want to display the MAC?